### PR TITLE
Fix typo: model -> models in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install -e .
 python download_wan2.1.py
 ```
 
-2. Download the [LongVie2 weights](https://huggingface.co/Vchitect/LongVie2) and place them in `./model/LongVie/`
+2. Download the [LongVie2 weights](https://huggingface.co/Vchitect/LongVie2) and place them in `./models/LongVie/`
 
 ### Inference
 


### PR DESCRIPTION
## Description

Fixed a typo in the README: changed `./model/LongVie/` to `./models/LongVie/` to match the correct directory path for placing the downloaded LongVie2 weights.